### PR TITLE
Set joins of path line to round, to avoid glitches on the map

### DIFF
--- a/src/gpx-viewer-path-layer.c
+++ b/src/gpx-viewer-path-layer.c
@@ -524,6 +524,7 @@ static gboolean redraw_path (GpxViewerPathLayer *layer)
 	cairo_set_line_width (cr, priv->stroke_width);
 	cairo_set_dash(cr, priv->dash, priv->num_dashes, 0);
 	cairo_set_line_cap(cr, CAIRO_LINE_CAP_ROUND);
+	cairo_set_line_join(cr, CAIRO_LINE_JOIN_ROUND);
 	for (elem = g_list_first(priv->track->points); elem != NULL; elem = elem->next)
 	{
 		GpxPoint *location = GPX_POINT (elem->data);


### PR DESCRIPTION
GPS tracks taken by my Garmin eTrex 30 are sometimes noisy when I'm having a halt somewhere.
As you can see on the following picture, the tiny direction changes are rendering big angles, due to the joins.
![Before the fix](http://i.imgur.com/W4fcEHr.png?1)
By setting the joins to rounded, we get a much softer render, as you can see on this picture (same GPX track).
![After the fix](http://i.imgur.com/rlJBc0P.png?1)